### PR TITLE
Allow the renderer argument to be null

### DIFF
--- a/src/Renderer/CompositeRenderer.php
+++ b/src/Renderer/CompositeRenderer.php
@@ -12,6 +12,13 @@ final class CompositeRenderer implements RendererInterface
     /** @var list<RendererInterface> */
     private array $renderers = [];
 
+    public function __construct(RendererInterface ...$renderers)
+    {
+        foreach ($renderers as $renderer) {
+            $this->add($renderer);
+        }
+    }
+
     public function add(RendererInterface $renderer): void
     {
         $this->renderers[] = $renderer;

--- a/src/TagBag.php
+++ b/src/TagBag.php
@@ -16,6 +16,9 @@ use Setono\TagBag\Exception\StorageException;
 use Setono\TagBag\Exception\UnsupportedTagException;
 use Setono\TagBag\Generator\FingerprintGeneratorInterface;
 use Setono\TagBag\Generator\ValueBasedFingerprintGenerator;
+use Setono\TagBag\Renderer\CompositeRenderer;
+use Setono\TagBag\Renderer\ContentAwareRenderer;
+use Setono\TagBag\Renderer\ElementRenderer;
 use Setono\TagBag\Renderer\RendererInterface;
 use Setono\TagBag\Storage\StorageInterface;
 use Setono\TagBag\Tag\RenderedTag;
@@ -34,11 +37,16 @@ final class TagBag implements TagBagInterface, LoggerAwareInterface
 
     private ?EventDispatcherInterface $eventDispatcher = null;
 
+    private readonly RendererInterface $renderer;
+
     private readonly FingerprintGeneratorInterface $fingerprintGenerator;
 
-    public function __construct(private readonly RendererInterface $renderer, FingerprintGeneratorInterface $fingerprintGenerator = null)
-    {
+    public function __construct(
+        RendererInterface $renderer = null,
+        FingerprintGeneratorInterface $fingerprintGenerator = null,
+    ) {
         $this->logger = new NullLogger();
+        $this->renderer = $renderer ?? new CompositeRenderer(new ElementRenderer(), new ContentAwareRenderer());
         $this->fingerprintGenerator = $fingerprintGenerator ?? new ValueBasedFingerprintGenerator();
     }
 


### PR DESCRIPTION
If you just want to use the default renderers (i.e. element and content renderer), you don't have to provide an argument for the renderer anymore on the `TagBag`